### PR TITLE
Feat: membership 생성,수정,삭제API

### DIFF
--- a/src/main/java/com/spring/coworker/group/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/spring/coworker/group/dto/request/GroupCreateRequest.java
@@ -2,12 +2,16 @@ package com.spring.coworker.group.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.UUID;
 
 public record GroupCreateRequest(
     @NotNull(message = "이름은 null이어서는 안됩니다.")
     @Size(min = 1, max = 20, message = "이름은 1-20자 사이여야 합니다.")
     String name,
-    String imageUrl
+    String imageUrl,
+
+    @NotNull(message = "사용자가 null이어서는 안됩니다.")
+    UUID userId
 ) {
 
 }

--- a/src/main/java/com/spring/coworker/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/spring/coworker/group/service/GroupServiceImpl.java
@@ -66,6 +66,8 @@ public class GroupServiceImpl implements GroupService {
   public void deleteGroup(UUID groupId) {
     Group group = groupRepository.findById(groupId)
         .orElseThrow(() -> new IllegalArgumentException("Group not found"));
+
+    membershipRepository.deleteAllByGroupId(groupId);
     groupRepository.deleteById(groupId);
   }
 }

--- a/src/main/java/com/spring/coworker/membership/controller/MembershipController.java
+++ b/src/main/java/com/spring/coworker/membership/controller/MembershipController.java
@@ -1,0 +1,39 @@
+package com.spring.coworker.membership.controller;
+
+import com.spring.coworker.membership.dto.request.MemberShipUpdateRequest;
+import com.spring.coworker.membership.dto.request.MembershipCreateRequest;
+import com.spring.coworker.membership.dto.response.MemberShipDto;
+import com.spring.coworker.membership.service.MembershipService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/memberships")
+@RequiredArgsConstructor
+public class MembershipController {
+  private final MembershipService membershipService;
+
+  @PostMapping("")
+  public ResponseEntity<MemberShipDto> createMembership(
+      @Valid @RequestBody MembershipCreateRequest membershipCreateRequest) {
+    MemberShipDto result = membershipService.create(membershipCreateRequest);
+    return ResponseEntity.ok(result);
+  }
+
+  @PatchMapping("/{membershipId}")
+  public ResponseEntity<MemberShipDto> updateMembership(
+      @PathVariable UUID membershipId, @Valid @RequestBody MemberShipUpdateRequest memberShipUpdateRequest) {
+    MemberShipDto result = membershipService.update(membershipId, memberShipUpdateRequest);
+    return ResponseEntity.ok(result);
+  }
+
+}

--- a/src/main/java/com/spring/coworker/membership/controller/MembershipController.java
+++ b/src/main/java/com/spring/coworker/membership/controller/MembershipController.java
@@ -36,4 +36,11 @@ public class MembershipController {
     return ResponseEntity.ok(result);
   }
 
+  @DeleteMapping("/{membershipId}")
+  public ResponseEntity<Void> deleteMembership(
+      @PathVariable UUID membershipId) {
+    membershipService.delete(membershipId);
+    return ResponseEntity.noContent().build();
+  }
+
 }

--- a/src/main/java/com/spring/coworker/membership/entity/MemberShip.java
+++ b/src/main/java/com/spring/coworker/membership/entity/MemberShip.java
@@ -79,4 +79,12 @@ public class MemberShip {
     this.role = role;
   }
 
+  public void updateRole(MembershipRole newRole){
+    if (newRole != null) {
+      if(!newRole.equals(this.role)) {
+        this.role = newRole;
+      }
+    }
+  }
+
 }

--- a/src/main/java/com/spring/coworker/membership/mapper/MembershipMapper.java
+++ b/src/main/java/com/spring/coworker/membership/mapper/MembershipMapper.java
@@ -1,0 +1,11 @@
+package com.spring.coworker.membership.mapper;
+
+import com.spring.coworker.membership.dto.response.MemberShipDto;
+import com.spring.coworker.membership.entity.MemberShip;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface MembershipMapper {
+  MemberShipDto toMembershipDto(MemberShip membership);
+
+}

--- a/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
+++ b/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<MemberShip,UUID> {
   boolean existsByUserIdAndGroupId(UUID userId, UUID groupId);
-
+  void deleteAllByGroupId(UUID groupId);
 }

--- a/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
+++ b/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
@@ -1,0 +1,9 @@
+package com.spring.coworker.membership.repository;
+
+import com.spring.coworker.membership.entity.MemberShip;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipRepository extends JpaRepository<UUID, MemberShip> {
+
+}

--- a/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
+++ b/src/main/java/com/spring/coworker/membership/repository/MembershipRepository.java
@@ -4,6 +4,7 @@ import com.spring.coworker.membership.entity.MemberShip;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MembershipRepository extends JpaRepository<UUID, MemberShip> {
+public interface MembershipRepository extends JpaRepository<MemberShip,UUID> {
+  boolean existsByUserIdAndGroupId(UUID userId, UUID groupId);
 
 }

--- a/src/main/java/com/spring/coworker/membership/service/MembershipService.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipService.java
@@ -1,0 +1,8 @@
+package com.spring.coworker.membership.service;
+
+import com.spring.coworker.membership.dto.request.MembershipCreateRequest;
+import com.spring.coworker.membership.dto.response.MemberShipDto;
+
+public interface MembershipService {
+  MemberShipDto create(MembershipCreateRequest request);
+}

--- a/src/main/java/com/spring/coworker/membership/service/MembershipService.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipService.java
@@ -1,8 +1,11 @@
 package com.spring.coworker.membership.service;
 
+import com.spring.coworker.membership.dto.request.MemberShipUpdateRequest;
 import com.spring.coworker.membership.dto.request.MembershipCreateRequest;
 import com.spring.coworker.membership.dto.response.MemberShipDto;
+import java.util.UUID;
 
 public interface MembershipService {
   MemberShipDto create(MembershipCreateRequest request);
+  MemberShipDto update(UUID membershipId,MemberShipUpdateRequest request);
 }

--- a/src/main/java/com/spring/coworker/membership/service/MembershipService.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipService.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 public interface MembershipService {
   MemberShipDto create(MembershipCreateRequest request);
   MemberShipDto update(UUID membershipId,MemberShipUpdateRequest request);
+  void delete(UUID membershipId);
 }

--- a/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
@@ -60,6 +60,12 @@ public class MembershipServiceImpl implements MembershipService {
     return membershipMapper.toMembershipDto(memberShip);
   }
 
+  @Override
+  public void delete(UUID membershipId) {
+    MemberShip memberShip = membershipRepository.findById(membershipId)
+        .orElseThrow(() -> new IllegalArgumentException("membership not found"));
+    membershipRepository.deleteById(membershipId);
+  }
 
 
 }

--- a/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
@@ -2,6 +2,7 @@ package com.spring.coworker.membership.service;
 
 import com.spring.coworker.group.entity.Group;
 import com.spring.coworker.group.repository.GroupRepository;
+import com.spring.coworker.membership.dto.request.MemberShipUpdateRequest;
 import com.spring.coworker.membership.dto.request.MembershipCreateRequest;
 import com.spring.coworker.membership.dto.response.MemberShipDto;
 import com.spring.coworker.membership.entity.MemberShip;
@@ -50,4 +51,15 @@ public class MembershipServiceImpl implements MembershipService {
     membershipRepository.save(memberShip);
     return membershipMapper.toMembershipDto(memberShip);
   }
+
+  @Override
+  public MemberShipDto update(UUID membershipId,MemberShipUpdateRequest request) {
+    MemberShip memberShip = membershipRepository.findById(membershipId)
+        .orElseThrow(() -> new IllegalArgumentException("membership not found"));
+    memberShip.updateRole(request.newRole());
+    return membershipMapper.toMembershipDto(memberShip);
+  }
+
+
+
 }

--- a/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
@@ -14,9 +14,11 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MembershipServiceImpl implements MembershipService {
 
   private final MembershipRepository membershipRepository;

--- a/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
+++ b/src/main/java/com/spring/coworker/membership/service/MembershipServiceImpl.java
@@ -1,0 +1,51 @@
+package com.spring.coworker.membership.service;
+
+import com.spring.coworker.group.entity.Group;
+import com.spring.coworker.group.repository.GroupRepository;
+import com.spring.coworker.membership.dto.request.MembershipCreateRequest;
+import com.spring.coworker.membership.dto.response.MemberShipDto;
+import com.spring.coworker.membership.entity.MemberShip;
+import com.spring.coworker.membership.entity.MembershipRole;
+import com.spring.coworker.membership.mapper.MembershipMapper;
+import com.spring.coworker.membership.repository.MembershipRepository;
+import com.spring.coworker.user.entity.User;
+import com.spring.coworker.user.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipServiceImpl implements MembershipService {
+
+  private final MembershipRepository membershipRepository;
+  private final MembershipMapper membershipMapper;
+  private final UserRepository userRepository;
+  private final GroupRepository groupRepository;
+
+  @Override
+  public MemberShipDto create(MembershipCreateRequest request) {
+    UUID userId = request.userId();
+    UUID groupId = request.groupId();
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("user not found"));
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new IllegalArgumentException("group not found"));
+    if(membershipRepository.existsByUserIdAndGroupId(userId, groupId)) {
+      throw new IllegalArgumentException("membership already exists");
+    }
+
+    Instant joinedAt = request.joinedAt();
+    MembershipRole role = request.role();
+    MemberShip memberShip = MemberShip.builder()
+        .group(group)
+        .user(user)
+        .role(role)
+        .joinedAt(joinedAt)
+        .build();
+
+    membershipRepository.save(memberShip);
+    return membershipMapper.toMembershipDto(memberShip);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관 이슈
#10 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📑 변경 사항
그룹 생성 시, 멤버쉽 로직 추가
그룹 삭제 시, 멤버쉽 삭제 로직 추가

POST /memberships
PATCH /{membership}
DELETE /{membership}

### ✅ 추가코멘트
membership이 연관관계 주인이다. 
membership service에서 create는 사용자가 기존 그룹에 참여할 때 사용하는 API이다.

그룹을 생성할 때, 그룹 생성하는 사람은 팀장이므로 그룹생성 로직에 membership저장하는 로직을 추가해두었다.

그룹을 삭제하면 관련 membership정보는 삭제된다.